### PR TITLE
Fix race condition when loading Google Maps InfoBox

### DIFF
--- a/src/admin/library/html/slocgoogle.php
+++ b/src/admin/library/html/slocgoogle.php
@@ -152,7 +152,7 @@ async function initGoogle() {
 }
 async function initMap(id, options) {
     setTimeout(function() {
-        if (!!google.maps) {
+        if (typeof google !== 'undefined' && !!google.maps && typeof InfoBox !== 'undefined') {
             let map = new jQuery.sloc.map.google();
             map.init(options);
             jQuery.sloc.map.register(id, map);


### PR DESCRIPTION
Wait until both Google Maps and the InfoBox script are available before initialising the map. 

This prevents the map and location list from failing to display when InfoBox loads after the map initialisation begins.